### PR TITLE
Added lastversion to the pip install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,21 +4,21 @@ WORKDIR /src
 
 ### 2. Get Java via the package manager
 RUN apk update \
-&& apk upgrade \
-&& apk add --no-cache bash \
-&& apk add --no-cache --virtual=build-dependencies unzip \
-&& apk add --no-cache curl \
-&& apk add --no-cache openjdk17
+    && apk upgrade \
+    && apk add --no-cache bash \
+    && apk add --no-cache --virtual=build-dependencies unzip \
+    && apk add --no-cache curl \
+    && apk add --no-cache openjdk17
 
 ### 3. Get Python, PIP
 
 RUN apk add --no-cache python3 \
-&& python3 -m ensurepip \
-&& pip3 install --upgrade pip setuptools \
-&& rm -r /usr/lib/python*/ensurepip && \
-if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi && \
-if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi && \
-rm -r /root/.cache
+    && python3 -m ensurepip \
+    && pip3 install --upgrade pip setuptools \
+    && rm -r /usr/lib/python*/ensurepip && \
+    if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi && \
+    if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi && \
+    rm -r /root/.cache
 
 ### install required packages
-RUN pip install colorama
+RUN pip install colorama lastversion


### PR DESCRIPTION
The `lastversion` python package was missing. Maybe we should integrate a `requirements.txt`?

<img width="633" alt="afbeelding" src="https://user-images.githubusercontent.com/29407220/180303300-031be1bb-c6cf-4836-ab2e-ef8b69efefa7.png">
